### PR TITLE
Move the image parameter to the end

### DIFF
--- a/lib/puppet/parser/functions/docker_service_flags.rb
+++ b/lib/puppet/parser/functions/docker_service_flags.rb
@@ -54,16 +54,16 @@ module Puppet::Parser::Functions
       end
     end
 
-    if opts['image'].to_s != 'undef'
-      flags << "'#{opts['image']}'"
-    end
-
     if opts['host_socket'].to_s != 'undef'
       flags << "-H '#{opts['host_socket']}'"
     end
 
     if opts['registry_mirror'].to_s != 'undef'
       flags << "--registry-mirror='#{opts['registry_mirror']}'"
+    end
+
+    if opts['image'].to_s != 'undef'
+      flags << "'#{opts['image']}'"
     end
 
     flags.flatten.join(' ')


### PR DESCRIPTION
Docker treats anything provided after the image parameter as a command that runs when the container is started. All parameters in should be before the image.

For example, attempting to create a mysql service using the current code would result in this command:
```
docker service create --name 'mysql_test_3' --publish '10001:3306' --replicas '1' --restart-condition any --constraint "node.role==worker" --mount "type=volume,source=mysql_snapshot_103,target=/var/lib/mysql,volume-driver=rexray" --env MYSQL_ROOT_PASSWORD=wordpress --env MYSQL_DATABASE=wordpress --env MYSQL_USER=wordpress --env MYSQL_PASSWORD=wordpress 'mariadb:latest' --registry-mirror=''
```
Which causes MySQL service to fail startup with the following error:
```
mysql_test_3.1.o9f9idtrcgvg@scva136.lss.emc.com    | 2018-03-13 15:04:15 139877072693120 [ERROR] mysqld: unknown variable 'registry-mirror='
mysql_test_3.1.o8cj5813r6ci@scva136.lss.emc.com    | 2018-03-13 15:05:11 139842998867840 [ERROR] Aborting
mysql_test_3.1.o9f9idtrcgvg@scva136.lss.emc.com    | 2018-03-13 15:04:15 139877072693120 [ERROR] Aborting
```